### PR TITLE
Add configuration to Nginx to support XMLRPC via scgi.

### DIFF
--- a/config/nginx/default
+++ b/config/nginx/default
@@ -6,10 +6,17 @@ server {
 
 	server_name "docktorrent";
 
-	location / {
-		auth_basic "Login Required";
-		auth_basic_user_file /usr/share/nginx/html/rutorrent/.htpasswd;
+	auth_basic "Login Required";
+	auth_basic_user_file /usr/share/nginx/html/rutorrent/.htpasswd;
 
+	location /RPC2 {
+		include scgi_params;
+		scgi_send_timeout 10s;
+		scgi_read_timeout 10s;
+		scgi_pass  unix:/tmp/rpc.socket;
+	}
+
+	location / {
 		try_files $uri $uri/ /index.html;
 	}
 


### PR DESCRIPTION
Hi,

This PR adds support for XMLRPC. I've also moved the auth logic to the server block, so it protects the PHP files that would otherwise be exposed. I did some light testing of adding, stopping and removing a torrent and I don't believe this introduces any new issues.

Example usage:

    $ python
    Python 2.7.6 (default, Mar 22 2014, 22:59:56) 
    [GCC 4.8.2] on linux2
    Type "help", "copyright", "credits" or "license" for more information.
    >>> import rtorrent
    >>> client = rtorrent.RTorrent('http://docktorrent:p@ssw0rd@172.20.102.195/RPC2')
    >>> client.get_torrents()
    [<Torrent info_hash="B415C913643E5FF49FE37D304BBB5E6E11AD5101" name="ubuntu-14.10-desktop-amd64.iso">]
    >>> 

Thanks,
Jay