### PR TITLE
Add a healthcheck to monitor rTorrent and restart it if it hangs.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -93,6 +93,10 @@ ADD s6-1.1.3.2-musl-static.tar.xz /
 # Service directories and the wrapper script
 COPY rootfs /
 
+# Symlink the healthcheck.
+RUN ln -s /usr/local/bin/rtorrent-healthcheck /service/rtorrent-healthcheck/run
+RUN ln -s /bin/true /service/rtorrent-healthcheck/finish
+
 # Run the wrapper script first
 ENTRYPOINT ["/usr/local/bin/docktorrent"]
 

--- a/config/nginx/default
+++ b/config/nginx/default
@@ -6,6 +6,10 @@ server {
 
 	server_name "docktorrent";
 
+	# Only localhost is allowed to access resources unauthenticated.
+	satisfy any;
+	allow 127.0.0.1;
+	deny all;
 	auth_basic "Login Required";
 	auth_basic_user_file /usr/share/nginx/html/rutorrent/.htpasswd;
 

--- a/rootfs/usr/local/bin/rtorrent-healthcheck
+++ b/rootfs/usr/local/bin/rtorrent-healthcheck
@@ -1,0 +1,32 @@
+#!/bin/bash
+################################################
+# rtorrent-healthcheck                         #
+# Monitor rtorrent and restart it if it hangs. #
+################################################
+
+# Interval, in seconds
+interval=30;
+
+# End of configuration
+
+while true
+do
+    # We sleep first to avoid any race when starting for the first time.
+    sleep $interval;
+
+    # Capture the HTTP status code when we send an XML request. If the API is
+    # available, we should get a 200 OK. When it's not, we generally get a
+    # Gateway Timeout from Nginx - but we aren't specifically looking for that.
+    status_code=$(
+      curl --silent \
+           --data '<ping></ping>' \
+           --write-out '%{http_code}' \
+           --output /dev/null \
+           http://localhost/RPC2 \
+    )
+    if [ "$status_code" != "200" ]
+    then
+            s6-svc -k /service/rtorrent;
+    fi
+done
+


### PR DESCRIPTION
Hi again,

I have a problem where sporadically, the rTorrent client becomes totally unresponsive. It won't even respond to a kill that isn't `-9`, so that tells me that there's little way we can recover from such a hang.

My workaround for this problem is to add a healthcheck script. It takes advantage of the XMLRPC support to make a simple API request to check the availability of the API. Nginx will automatically time out the request after 10s, giving a HTTP 504 Gateway Timeout, triggering a kill.

Until #7 is fixed (code or my understanding) this will currently cause the container to shut down. However, I can provide a separate PR to ensure it always restarts successfully if my understanding of #7 is correct.

Thanks,
Jay