### PR TITLE
Create user-profiles/torrents at container start

### DIFF
--- a/rootfs/usr/local/bin/docktorrent
+++ b/rootfs/usr/local/bin/docktorrent
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Create working directories if not exists
-mkdir -p /rtorrent/{downloads,watch,.session,rutorrent/user-profiles}
+mkdir -p /rtorrent/{downloads,watch,.session,rutorrent/user-profiles,rutorrent/user-profiles/torrents}
 
 # Change permission to ruTorrent's webserver user
 chown -R www-data:www-data /rtorrent


### PR DESCRIPTION
Fixes problem with being unable to add torrents.
This doesn't happen every time for me though.