### PR TITLE
Permit alternate download paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Override settings in `.rtorrent.rc`:
   - **MAX_UPLOADS** overrides `max_uploads`.
   - **DOWNLOAD_RATE** overrides `download_rate`.
   - **UPLOAD_RATE** overrides `upload_rate`.
+  - **DOWNLOAD_DIR** overrides `download`.
 
 ## Requirement
 

--- a/config/rutorrent/config.php
+++ b/config/rutorrent/config.php
@@ -24,7 +24,7 @@
 	$saveUploadedTorrents = true;		// Save uploaded torrents to profile/torrents directory or not
 	$overwriteUploadedTorrents = false;     // Overwrite existing uploaded torrents in profile/torrents directory or make unique name
 
-	$topDirectory = '/rtorrent/';		// Upper available directory. Absolute path with trail slash.
+	$topDirectory = '/';		// Upper available directory. Absolute path with trail slash.
 	$forbidUserSettings = false;
 
 	# $scgi_port = 5000;

--- a/rootfs/usr/local/bin/docktorrent
+++ b/rootfs/usr/local/bin/docktorrent
@@ -31,6 +31,10 @@ chown -R www-data:www-data /rtorrent
     sed -i '/^upload_rate =/d' /root/.rtorrent.rc
     echo "upload_rate = ${UPLOAD_RATE}" >> /root/.rtorrent.rc
 }
+[ "${DOWNLOAD_DIR}" ] && {
+    sed -i '/^download =/d' /root/.rtorrent.rc
+    echo "download = ${DOWNLOAD_DIR}" >> /root/.rtorrent.rc
+}
 
 # Turn off all logs
 [ "${LOGS_OFF}" == "yes" ] || [ "${LOGS_OFF}" == "y" ] && {

--- a/rootfs/usr/local/bin/docktorrent
+++ b/rootfs/usr/local/bin/docktorrent
@@ -32,8 +32,8 @@ chown -R www-data:www-data /rtorrent
     echo "upload_rate = ${UPLOAD_RATE}" >> /root/.rtorrent.rc
 }
 [ "${DOWNLOAD_DIR}" ] && {
-    sed -i '/^download =/d' /root/.rtorrent.rc
-    echo "download = ${DOWNLOAD_DIR}" >> /root/.rtorrent.rc
+    sed -i '/^directory =/d' /root/.rtorrent.rc
+    echo "directory = ${DOWNLOAD_DIR}" >> /root/.rtorrent.rc
 }
 
 # Turn off all logs


### PR DESCRIPTION
Presently it's configured so that you have to place all downloads in /rtorrent. Normally there's nothing inherently wrong with this, except if you integrate rtorrent with other applications (such as sickrage or couchpotato) you may prefer to be able to bring in a root path based volume, that way you can keep the pathing consistent across applications.
