### PR TITLE
Rework.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,75 +2,30 @@ FROM debian:jessie
 
 MAINTAINER kfei <kfei@kfei.net>
 
-ENV VER_LIBTORRENT 0.13.4
-ENV VER_RTORRENT 0.9.4
-
 WORKDIR /usr/local/src
 
-# This long disgusting instruction saves your image ~130 MB
-RUN build_deps="automake build-essential ca-certificates libc-ares-dev libcppunit-dev libtool"; \
-    build_deps="${build_deps} libssl-dev libxml2-dev libncurses5-dev pkg-config subversion wget"; \
-    set -x && \
-    apt-get update && apt-get install -q -y --no-install-recommends ${build_deps} && \
-    wget http://curl.haxx.se/download/curl-7.39.0.tar.gz && \
-    tar xzvfp curl-7.39.0.tar.gz && \
-    cd curl-7.39.0 && \
-    ./configure --enable-ares --enable-tls-srp --enable-gnu-tls --with-zlib --with-ssl && \
-    make && \
-    make install && \
-    cd .. && \
-    rm -rf curl-* && \
-    ldconfig && \
-    svn --trust-server-cert checkout https://svn.code.sf.net/p/xmlrpc-c/code/stable/ xmlrpc-c && \
-    cd xmlrpc-c && \
-    ./configure --enable-libxml2-backend --disable-abyss-server --disable-cgi-server && \
-    make && \
-    make install && \
-    cd .. && \
-    rm -rf xmlrpc-c && \
-    ldconfig && \
-    wget -O libtorrent-$VER_LIBTORRENT.tar.gz https://github.com/rakshasa/libtorrent/archive/$VER_LIBTORRENT.tar.gz && \
-    tar xzf libtorrent-$VER_LIBTORRENT.tar.gz && \
-    cd libtorrent-$VER_LIBTORRENT && \
-    ./autogen.sh && \
-    ./configure --with-posix-fallocate && \
-    make && \
-    make install && \
-    cd .. && \
-    rm -rf libtorrent-* && \
-    ldconfig && \
-    wget -O rtorrent-$VER_RTORRENT.tar.gz https://github.com/rakshasa/rtorrent/archive/$VER_RTORRENT.tar.gz && \
-    tar xzf rtorrent-$VER_RTORRENT.tar.gz && \
-    cd rtorrent-$VER_RTORRENT && \
-    ./autogen.sh && \
-    ./configure --with-xmlrpc-c --with-ncurses && \
-    make && \
-    make install && \
-    cd .. && \
-    rm -rf rtorrent-* && \
-    ldconfig && \
-    mkdir -p /usr/share/nginx/html && \
+RUN DEBIAN_FRONTEND=noninteractive && \
+    apt-get update && \
+    apt-get install --assume-yes \
+        ca-certificates \
+        curl \
+        rtorrent \
+        wget \
+        apache2-utils \
+        nginx \
+        php5-cli \
+        php5-fpm \
+        mediainfo \
+        unrar-free \
+        unzip
+
+RUN set -x && \
+    mkdir --parent /usr/share/nginx/html && \
     cd /usr/share/nginx/html && \
     mkdir rutorrent && \
-    curl -L -O https://github.com/Novik/ruTorrent/archive/master.tar.gz && \
-    tar xzvf master.tar.gz -C rutorrent --strip-components 1 && \
-    rm -rf *.tar.gz && \
-    apt-get purge -y --auto-remove ${build_deps} && \
-    apt-get autoremove -y
-
-# Install required packages
-RUN apt-get update && apt-get install -q -y --no-install-recommends \
-    apache2-utils \
-    libc-ares2 \
-    nginx \
-    php5-cli \
-    php5-fpm
-
-# Install packages for ruTorrent plugins
-RUN apt-get update && apt-get install -q -y --no-install-recommends \
-    mediainfo \
-    unrar-free \
-    unzip
+    curl --location --remote-name https://github.com/Novik/ruTorrent/archive/master.tar.gz && \
+    tar --extract --gzip --file master.tar.gz --directory rutorrent --strip-components 1 && \
+    rm -rf *.tar.gz
 
 # For ffmpeg, which is required by the ruTorrent screenshots plugin
 # This increases ~53 MB of the image size, remove it if you really don't need screenshots

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,28 @@
+## For more examples of a Makefile based Docker container deployment see: https://github.com/ypid/docker-makefile
+
+DOCKER_RUN_OPTIONS ?= --env "TZ=Europe/Berlin"
+
+image_bittorrent        ?= kfei/bittorrent
+
+.PHONY: default build build-dev run bittorrent
+
+default: run
+
+build:
+	docker build --no-cache=true --tag $(image_bittorrent) .
+
+build-dev:
+	docker build --no-cache=false --tag $(image_bittorrent) .
+
+run: bittorrent
+
+bittorrent:
+	-@docker rm --force "$@"
+	docker run --interactive --tty \
+		--name "$@" \
+		$(DOCKER_RUN_OPTIONS) \
+		--publish 80:80 \
+		--publish 45566:45566 \
+		--publish 9527:9527/udp \
+		--volume /srv/bittorrent:/rtorrent \
+		$(image_bittorrent)

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ BitTorrent box.
 ## Highlights
 
   - All-in-one Docker container, build once and run everywhere.
-  - Newest version of rTorrent and ruTorrent, with support of DHT and
-    asynchronous DNS which will result in a more responsive rTorrent.
+  - rTorrent and ruTorrent, with support of DHT and
+    asynchronous DNS which will results in a more responsive rTorrent.
   - Enable all useful ruTorrent plugins by default.
   - Get a working BitTorrent box in less than 3 minutes, give it a quick try
     and tune the configs later.

--- a/config/rutorrent/config.php
+++ b/config/rutorrent/config.php
@@ -40,7 +40,7 @@
 
 	$pathToExternals = array(
 		"php" 	=> '',			// Something like /usr/bin/php. If empty, will be found in PATH.
-		"curl"	=> '/usr/local/bin/curl',			// Something like /usr/bin/curl. If empty, will be found in PATH.
+		"curl"	=> '',			// Something like /usr/bin/curl. If empty, will be found in PATH.
 		"gzip"	=> '',			// Something like /usr/bin/gzip. If empty, will be found in PATH.
 		"id"	=> '',			// Something like /usr/bin/id. If empty, will be found in PATH.
 		"stat"	=> '',			// Something like /usr/bin/stat. If empty, will be found in PATH.
@@ -56,4 +56,8 @@
 						// Both Webserver and rtorrent users must have read-write access to it.
 						// For example, if Webserver and rtorrent users are in the same group then the value may be 0770.
 
-	$tempDirectory = null;                  // Temp directory. Absolute path with trail slash. If null, then autodetect will be used.
+	$tempDirectory = null;			// Temp directory. Absolute path with trail slash. If null, then autodetect will be used.
+
+	$canUseXSendFile = true;		// Use X-Sendfile feature if it exist
+
+	$locale = "UTF8";


### PR DESCRIPTION
Related to #21. With this changes, maintenance will be much easier in the long run. You don’t have to merge this in right away because it will actually downgrade to rtorrent 0.9.2, libtorrent 0.13.2 and curl 7.38.

Confirmed working:
- torrent download
