### PR TITLE
Fixed potential vulnerability because PGP key is installed insecurely.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -75,7 +75,8 @@ RUN apt-get update && apt-get install -q -y --no-install-recommends \
 # For ffmpeg, which is required by the ruTorrent screenshots plugin
 # This increases ~53 MB of the image size, remove it if you really don't need screenshots
 RUN echo "deb http://www.deb-multimedia.org jessie main" >> /etc/apt/sources.list && \
-    apt-get update && apt-get install -q -y --force-yes --no-install-recommends \
+    apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys A401FF99368FA1F98152DE755C808C2B65558117 && \
+    apt-get update && apt-get install -q -y --no-install-recommends \
     deb-multimedia-keyring \
     ffmpeg
 


### PR DESCRIPTION
From apt-get(8).

```
--force-yes
    Force yes; this is a dangerous option that will cause apt to continue without prompting if it is doing something potentially harmful. It should not be used
    except in very special situations. Using force-yes can potentially destroy your system! Configuration Item: APT::Get::force-yes.
```

Didn’t read the manpage? :wink: :grimacing: